### PR TITLE
Fix loading image on http to https to remove warning on the browser

### DIFF
--- a/frontend/src/components/InfoRow.vue
+++ b/frontend/src/components/InfoRow.vue
@@ -10,7 +10,7 @@
             <InfoCard
                 class="col-sm-10 offset-sm-1 col-lg-4 offset-lg-0"
                 :title="$t('info.sponsors.title')"
-                image_src="http://d36m266ykvepgv.cloudfront.net/uploads/media/HsFp1O2KHY/s-368-252/icon-sponsors2.png"
+                image_src="https://d36m266ykvepgv.cloudfront.net/uploads/media/HsFp1O2KHY/s-368-252/icon-sponsors2.png"
                 :description="$t('info.sponsors.desc')"
                 :link="$t('info.sponsors.file')"
                 :button_text="$t('info.sponsors.button')"


### PR DESCRIPTION
Hola,

Le estaba echando un vistazo rápido a la web y he visto que me saltaba una alerta de `mixed content` ya que hay una imagen que se carga mediante `http` en vez de `https`. Estaría bien cambiarlo ya que la imagen se puede cargar mediante https.

```
Mixed Content: The page at 'https://2019.es.pycon.org/' was loaded over HTTPS, but requested an insecure image 'http://d36m266ykvepgv.cloudfront.net/uploads/media/HsFp1O2KHY/s-368-252/icon-sponsors2.png'. This content should also be served over HTTPS.
```

![image](https://user-images.githubusercontent.com/639755/56967078-7d844980-6b2e-11e9-9538-94bb9ab5baf5.png)


Saludos,
Raúl 